### PR TITLE
fix(command): define global command instead of buffer-local command for :Fzm

### DIFF
--- a/plugin/fuzzymenu.vim
+++ b/plugin/fuzzymenu.vim
@@ -153,7 +153,7 @@ endif
 
 ""
 " Fzm invokes fuzzymenu
-command -bang -nargs=0 -buffer Fzm call fuzzymenu#Run({'fullscreen': <bang>0})
+command -bang -nargs=0 Fzm call fuzzymenu#Run({'fullscreen': <bang>0})
 
 ""
 " GGrep finds a file using git as a base dir


### PR DESCRIPTION
Define `:Fzm` as global command to be able to execute in every buffer.