### PR TITLE
fix(command): use :command! to replace original :Fzm command

### DIFF
--- a/plugin/fuzzymenu.vim
+++ b/plugin/fuzzymenu.vim
@@ -162,7 +162,7 @@ endif
 
 ""
 " Fzm invokes fuzzymenu
-command -bang -nargs=0 Fzm call fuzzymenu#Run({'fullscreen': <bang>0})
+command! -bang -nargs=0 Fzm call fuzzymenu#Run({'fullscreen': <bang>0})
 
 ""
 " GGrep finds a file using git as a base dir


### PR DESCRIPTION
Use `:command!` to replace original :Fzm command to avoid error when reloading `.vimrc`.