### PR TITLE
Fix 'i' character being displayed

### DIFF
--- a/autoload/fuzzymenu.vim
+++ b/autoload/fuzzymenu.vim
@@ -289,14 +289,18 @@ function! s:MenuSink(mode, fl, ll, arg) abort
 endfunction
 
 function! fuzzymenu#InsertModeIfNvim() abort
-     if has("nvim")
-       startinsert
+     if has("nvim-0.5")
+         startinsert
+     elseif has("nvim")
+         call feedkeys('i')
      endif
 endfunction
 
 function! fuzzymenu#InsertMode() abort
-     if has("nvim")
-       startinsert
+     if has("nvim-0.5")
+         startinsert
+     elseif has("nvim")
+         call feedkeys('i')
      else
        startinsert
      endif

--- a/autoload/fuzzymenu.vim
+++ b/autoload/fuzzymenu.vim
@@ -290,13 +290,13 @@ endfunction
 
 function! fuzzymenu#InsertModeIfNvim() abort
      if has("nvim")
-       call feedkeys('i')
+       startinsert
      endif
 endfunction
 
 function! fuzzymenu#InsertMode() abort
      if has("nvim")
-       call feedkeys('i')
+       startinsert
      else
        startinsert
      endif


### PR DESCRIPTION
When we enter insert mode in neovim the 'i' character appears at the start of every search due to the feedcharacter function being used currently. For example when we select to search through 'Vim Commands' we need to backspace the 'i' character away each time before we can start typing in some text -- unless our search string starts with i of course :)
We can probably remove the entire neovim logic here and make the code more portable but that will need just a few more tweaks
Perhaps earlier versions of nvim did not support `startinsert` command and is the reason for this added logic, however I have tested on the nightly 5.0 version release as of December 20 and it is now working correctly. These changes will fix the problem as is and should be okay for now.